### PR TITLE
Fix bug in _update_telegraf when some RTTs are undefined.

### DIFF
--- a/lib/Pingmachine/Order.pm
+++ b/lib/Pingmachine/Order.pm
@@ -324,9 +324,11 @@ sub _update_telegraf {
 
         $telegraf_socket->send($influx_line,0) or die("Cannot send message");
 
-        for my $i (0..$successful_pings-1) {
+        for my $i (0..$all_pings-1) {
             my $time = $rrd_time + $step * $i / $successful_pings;
             my $result_time = sprintf("%d%09d", $time , ($time - int($time)) * 1_000_000_000);
+
+            next if (! $rtts[$i]);
             $influx_line = data2line($measurement_name, { individual_rtt => $rtts[$i]}, $tags, $result_time);
 
             $telegraf_socket->send($influx_line,0) or die("Cannot send message");


### PR DESCRIPTION
When not all pings are successful `@rtts` contains `undef`. This PR fixes an issue where the value for `individual_rtt` does not get set and causes an ingestion error in InfluxDB (data type conflict between `float` and "nothing" which is interpreted as `string`).

The issue is that we execute the `for` loop below `$successful_pings` times and use `$i` as index on `@rtts`, which is of larger cardinality in the case of unsuccessful pings. If the result of the unsuccessful ping is not at the end then `$i` accesses this value and uses it in the point written in InfluxDB LineProtocol.

The fix consists in looping over the amount of all pings and ignoring results that are `undef`, while still increasing the time step. This does also preserves order of ping results received including a "hole" in the measurement where there was no result.