### PR TITLE
include ignore http codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,9 @@ Note that the source interface and IP are optional. The [fping](https://fping.or
         url: http://www.example.com
         user_agent: pingmachine
         proxy: http://10.0.0.24:8080
+        http_codes_as_failure: 403,407,503
 
-Note that the user_agent and the proxy configuration are optional. The [httping](https://www.vanheusden.com/httping/) utility must be installed on the system.
+Note that the user_agent, the proxy and the http_codes_as_failure configuration are optional. The [httping](https://www.vanheusden.com/httping/) utility must be installed on the system.
 
 
 

--- a/lib/Pingmachine/Order/HTTPing.pm
+++ b/lib/Pingmachine/Order/HTTPing.pm
@@ -23,12 +23,18 @@ has 'proxy' => (
     is  => 'ro',
 );
 
+has 'http_codes_as_failure' => (
+    isa => 'Str',
+    is => 'ro',
+);
+
 sub probe_instance_key {
     my ($self) =@_;
 
     my @keys;
     push (@keys, "interval:".$self->interval)       if ($self->interval);
     push (@keys, "user_agent:".$self->user_agent)   if ($self->user_agent);
+    push (@keys, "http_codes_as_failure:".$self->http_codes_as_failure)   if ($self->http_codes_as_failure);
     push (@keys, "proxy:".$self->proxy)             if ($self->proxy);
     return join('|', @keys);
 }

--- a/lib/Pingmachine/Probe/HTTPing.pm
+++ b/lib/Pingmachine/Probe/HTTPing.pm
@@ -146,7 +146,7 @@ sub _start_new_job {
 }
 
 sub _kill_current_job {
-     my ($self) = @_;
+    my ($self) = @_;
 
     # Kill httping, if still running
     my $job = $self->current_job;

--- a/lib/Pingmachine/Probe/HTTPing.pm
+++ b/lib/Pingmachine/Probe/HTTPing.pm
@@ -205,9 +205,9 @@ sub _collect_current_job {
             }
             # if http codes to be considered as failures are defined and the line contains one of them, ignore the rtt value and add a -
             elsif ($self->http_codes_as_failure) {
-                # replace for example 403,407 with 403 [A-Z][a-z]+| 407 [A-Z][a-z]+ to match response codes 403 Forbidden, 407 Proxy Authentication Required
-                my $httping_errors .= $self->http_codes_as_failure =~ s/,/ [A-Z]+[a-z]*|/gr;
-                $httping_errors .=  ' [A-Z]+[a-z]*';
+                # replace for example 403,407 with (403|407) [A-Z]+[a-z]*(\s[A-Z]+[a-z]*)? to match response codes 403 Forbidden, 407 Proxy Authentication Required
+                my $httping_errors = $self->http_codes_as_failure =~ s/,/|/gr;
+                $httping_errors = '(' . $httping_errors  . ') [A-Z]+[a-z]*(\s[A-Z]+[a-z]*)?';
                 if ($line =~ /$httping_errors/) {
                     push @pings, undef;
                 }

--- a/lib/Pingmachine/ProbeList.pm
+++ b/lib/Pingmachine/ProbeList.pm
@@ -91,6 +91,7 @@ sub add_order {
                 pings      => $order->pings,
                 interval   => $order->httping->interval || 0,
                 user_agent => $order->httping->user_agent || '',
+                http_codes_as_failure => $order->httping->http_codes_as_failure || '',
                 proxy      => $order->httping->proxy || '',
             );
         }


### PR DESCRIPTION
if httping returns an http code included in the configuration, ignore the rtt result (add a -) and handle it as a failure 