### PR TITLE
Handle httping exit code 127

### DIFF
--- a/lib/Pingmachine/Probe/HTTPing.pm
+++ b/lib/Pingmachine/Probe/HTTPing.pm
@@ -129,9 +129,10 @@ sub _start_new_job {
             }
             my $exit = $cbv->recv;
             $exit = $exit >> 8;
-            if($exit and $exit != 1 and $exit != 2) {
+            if($exit and $exit != 1 and $exit != 2 and $exit != 127) {
                 # exit 1 means that some urls aren't reachable
                 # exit 2 means "any IP addresses were not found"
+                # exit 127 means that the connection is actively refused
                 $log->warning("httping seems to have failed (exit: $exit, httping output:\n" . Dumper(\$job{output}) . ")");
                 return;
             }  


### PR DESCRIPTION
Httping exits with 127 means that 'connection is actively refused' according to [1].
At the moment this is handled as an unexted error of httping. Which means that the
last_result file is not written. However connections that are refused shuld be reported as
100% packet loss by pingmachine. This is achieved with this change.

[1] https://fm4dd.com/programming/shell/proxy-clustercontrol.shtm