### PR TITLE
Fix status lookup in subfolders

### DIFF
--- a/pingmachine-status
+++ b/pingmachine-status
@@ -157,7 +157,7 @@ sub scan_orders_dir {
         my $order_id = $order_id_prefix ? "$order_id_prefix/$order_file" : $order_file;
         my $order_path = "$orders_dir/$order_file";
         if (-d $order_path) {
-            scan_orders_dir($order_path, $order_id, $orders, $orders_by_user, $any_ipv6);
+            ($orders, $orders_by_user, $any_ipv6) = scan_orders_dir($order_path, $order_id, $orders, $orders_by_user, $any_ipv6);
         }
 
         next unless -f $order_path;


### PR DESCRIPTION
Also collect status of orders in subfolders of the /orders folder.

This makes status collection work when running in a perl 5.34 environment and using orders in subfolders.